### PR TITLE
Removed --load-images from CLI args for phantomjs

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -82,7 +82,7 @@ server._pluginEvent = function(methodName, args, callback) {
 server.createPhantom = function() {
     var _this = this;
 
-    var args = ["--load-images=false", "--ignore-ssl-errors=true", "--ssl-protocol=tlsv1"];
+    var args = ["--ignore-ssl-errors=true", "--ssl-protocol=tlsv1"];
 
     if(this.options.phantomArguments) {
         args = this.options.phantomArguments;


### PR DESCRIPTION
Ticket #2232

Pre-render had a default command line argument of "--load images=false" which prevented the map from loading.  It appears PhantomJS 2.0 fixed a bug that caused PhantomJS 1.9 to disregard this command line argument.  