### PR TITLE
Add phantom logging level options via PHANTOM_STDOUT env var

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,12 +1,26 @@
 #!/usr/bin/env node
 var prerender = require('./lib');
 
-var server = prerender({
+var options = {
     workers: process.env.PHANTOM_CLUSTER_NUM_WORKERS,
     iterations: process.env.PHANTOM_WORKER_ITERATIONS || 10,
     phantomBasePort: process.env.PHANTOM_CLUSTER_BASE_PORT || 12300,
     messageTimeout: process.env.PHANTOM_CLUSTER_MESSAGE_TIMEOUT
-});
+};
+
+var phantomStdout = process.env.PHANTOM_STDOUT;
+
+if (phantomStdout === 'mute') {
+  options.onStdout = function() {};
+} else if (phantomStdout === 'quiet') {
+  options.onStdout = function(data) {
+    if (data && data.indexOf('Error:') > 0) {
+      return console.log('phantom stdout: ' + data);
+    }
+  };
+}
+
+var server = prerender(options);
 
 // basicAuth whitelist blacklist logger removeScriptTags httpHeaders inMemoryHtmlCache s3HtmlCache
 var plugins = process.env.PRERENDER_PLUGINS || 'blacklist,removeScriptTags,httpHeaders';


### PR DESCRIPTION
fixes: https://github.com/zumper/zumper_code/issues/3840

The logging you want to mute/quiet is being generated by the PhantomJS workers, not by Prerender.  So overriding Prerender's console.log() wouldn't prevent the Phantom logging.  Luckily,  Phantom takes 'onStdout' and 'onStderr' options and will use the provided functions instead of its own for logging.  

I think the best place to add the 'onStdout' and 'onStderr' options is in server.js along side the other phantom options that get passed to prerender (see below).  

I tested my solution by putting the following code on line 117 of node_modules/phantom/phantom.js:

```    
       setInterval(options.onStdout || function(data) {
          return console.log("phantom stdout: " + data);
        }.bind(this, 'testing stdout'), 2000)

       setInterval(options.onStderr || function(data) {
          return module.exports.stderrHandler(data.toString('utf8'));
        }.bind(this, 'testing stderr'), 2000)
```

The solution mutes stderr and stdout as expected based on the value of the env.PHANTOM_STDOUT.