### PR TITLE
add additional logging. fixes #5388

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var cluster = require('cluster')
 // fix resource leak, per:
 // https://github.com/nodejs/node-v0.x-archive/issues/9409#issuecomment-84038111
 function workAround(worker) {
+  util.info('Worker #' + worker.id + ' (pid ' + worker.process.pid + '): reporting for duty');
   var listeners = null;
 
   listeners = worker.process.listeners('exit')[0];
@@ -45,12 +46,12 @@ exports = module.exports = function(options) {
     if(cluster.isMaster) {
 
         for (var i = 0; i < (options.workers || os.cpus().length); i += 1) {
-            util.log('starting worker thread #' + i);
+            util.info('Master: starting worker #' + (i + 1));
             workAround(cluster.fork());
         }
 
         cluster.on('exit', function (worker) {
-            util.log('worker ' + worker.id + ' died, restarting!');
+            util.warn('Master: worker #' + worker.id + ' (pid ' + worker.process.pid + ') died, starting new worker');
             workAround(cluster.fork());
         });
     } else {
@@ -61,7 +62,7 @@ exports = module.exports = function(options) {
         var httpServer = http.createServer(_.bind(server.onRequest, server));
 
         httpServer.listen(port, function () {
-            util.log('Server running on port ' + port);
+            util.info('Worker (pid ' + process.pid + '): ' + 'Server running on port ' + port);
         });
     }
 

--- a/lib/plugins/screenshotter.js
+++ b/lib/plugins/screenshotter.js
@@ -3,6 +3,7 @@ var crypto = require('crypto'),
     path = require('path'),
     url = require('url'),
     zlib = require('zlib');
+    util = require('./../util.js')
 
 var dirPath = process.env.SCREENSHOT_TMP_DIR || '/tmp/'; 
 var reapInterval = process.env.SCREENSHOT_REAP_INTERVAL || 60000;
@@ -22,12 +23,17 @@ module.exports = {
       setInterval(utils.unlinkOldFiles.bind(this, dirPath, reapInterval));
     },
 
+    beforePhantomRequest: function(req, res, next) {
+      var parts = url.parse(req.url, true);
+      req.prerender.url = parts.query.url;
+      next();
+    },
+
     onPhantomPageCreate: function(phantom, req, res, next) {
       var parts = url.parse(req.url, true);
       var outputFormat = parts.query.outputFormat || defaultOutputFormat;
       
-      // Set url and headers for phantom GET request
-      req.prerender.url = parts.query.url;
+      //Set headers for phantom request
       var headers = parts.query.headers;
       if (typeof headers === 'string') {
         req.prerender.page.setHeaders(JSON.parse(headers));
@@ -98,7 +104,7 @@ module.exports = {
           utils.unlinkFile(filePath);
           delete tmpFiles[fileName];
           var ms = Date.now() - req.prerender.start.getTime();
-          console.log('got', req.prerender.statusCode, 'in', ms + 'ms', 'for', req.prerender.url);
+          util.info('Worker (pid ' + process.pid + '): got', req.prerender.statusCode, 'in', ms + 'ms', 'for', req.prerender.url);
           next();
         });
       });
@@ -111,7 +117,7 @@ module.exports = {
           delete tmpFiles[key];
         }
         catch (e) {
-          console.log('ERROR deleting screenshot: ' + key + ', Error=' + e); 
+          util.error('Worker (pid ' + process.pid + '): ERROR deleting screenshot: ' + key + ', Error=' + e);
         }
         
       });
@@ -133,7 +139,7 @@ var utils = {
         if (e.code !== 'ENOENT') {
           throw e;
         }
-        console.log('Tried erasing file ' + filePath + ' but ENOENT thrown, skipping...');
+        util.warn('Worker (pid ' + process.pid + '): Tried erasing file ' + filePath + ' but ENOENT thrown, skipping...');
       }
     }
   },
@@ -147,14 +153,14 @@ var utils = {
           var filePath = path.join(dirPath, file);
           var stats = fs.statSync(filePath);
           if (stats.isFile() && expireTime > stats.mtime.getTime()) {
-            console.log('Erasing file: ' + filePath + ' (older than ' + ttl + 'ms)');
+            util.info('Worker (pid ' + process.pid + '): Erasing file: ' + filePath + ' (older than ' + ttl + 'ms)');
             fs.unlinkSync(filePath);
           }
         } catch (e) {
           if (e.code !== 'ENOENT') {
             throw e;
           }
-          console.log('Tried erasing file ' + filePath + ' but ENOENT thrown, skipping...');
+          util.warn('Worker (pid ' + process.pid + '): Tried erasing file ' + filePath + ' but ENOENT thrown, skipping...');
         }
       }
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -92,14 +92,14 @@ server.createPhantom = function() {
 
     var port = (this.options.phantomBasePort || 12300) + (this.options.worker.id % 200);
 
-    util.log('starting phantom on port [' + port + ']');
+    util.info('Worker (pid ' + process.pid + '): starting phantom on port [' + port + ']');
 
     var opts = {
         port: port,
         binary: process.env.PHANTOMJS_BINARY || require('phantomjs').path,
         onExit: function() {
             _this.phantom = null;
-            util.log('phantom crashed, restarting...');
+            util.warn('phantom crashed, restarting...');
             process.nextTick(_.bind(_this.createPhantom, _this));
         }
     };
@@ -120,12 +120,14 @@ server.createPhantom = function() {
 };
 
 server.onPhantomCreate = function(phantom) {
-    util.log('started phantom');
+    util.info('Worker (pid ' + process.pid + '): started phantom');
     this.phantom = phantom;
     this.phantom.id = Math.random().toString(36);
 };
 
 server.onRequest = function(req, res) {
+    util.debug('Worker (pid ' + process.pid + '): request received ' + req.url);
+
     if (req.url === '/') {
         // health check.
         return res.end('prerender healthy');
@@ -138,6 +140,7 @@ server.onRequest = function(req, res) {
     req.prerender = util.prepareState(req, DOUBLE_ENDCODE_UNSAFE_URI);
 
     this._pluginEvent("beforePhantomRequest", [req, res], function() {
+        util.info('Worker (pid ' + process.pid + '): requested ' + req.prerender.url);
         _this.createPage(req, res);
     });
 };
@@ -152,6 +155,7 @@ server.createPage = function(req, res) {
     } else {
         req.prerender.phantomId = this.phantom.id;
         this.phantom.createPage(function(page){
+            util.info('Worker (pid ' + process.pid + '): prepping ' + req.prerender.url);
             req.prerender.page = page;
             _this.onPhantomPageCreate(req, res);
         });
@@ -190,7 +194,7 @@ server.onPhantomPageCreate = function(req, res) {
                 _this.checkIfPageIsDoneLoading(req, res, req.prerender.status === 'fail');
             }, (req.prerender.pageDoneCheckTimeout || _this.options.pageDoneCheckTimeout || PAGE_DONE_CHECK_TIMEOUT));
 
-            util.log('getting', req.prerender.url);
+            util.info('Worker (pid ' + process.pid + '): getting', req.prerender.url);
 
             req.prerender.page.open(req.prerender.url, function(status) {
                 req.prerender.status = status;
@@ -330,7 +334,7 @@ server.checkIfJavascriptTimedOut = function(req, res) {
     var noJsExecutionInFirstSecond = !req.prerender.lastJavascriptExecution && (new Date().getTime() - req.prerender.downloadFinished.getTime() > (req.prerender.noJsExecutionTimeout || this.options.noJsExecutionTimeout || NO_JS_EXECUTION_TIMEOUT));
 
     if (!this.phantom || this.phantom.id !== req.prerender.phantomId) {
-        util.log('PhantomJS restarted in the middle of this request. Aborting...');
+        util.warn('Worker (pid ' + process.pid + '): PhantomJS restarted in the middle of this request. Aborting...');
         clearInterval(req.prerender.timeoutChecker);
         req.prerender.timeoutChecker = null;
 
@@ -341,14 +345,14 @@ server.checkIfJavascriptTimedOut = function(req, res) {
         req.prerender.timeoutChecker = null;
 
         if (req.prerender.statusCode === undefined) {
-          util.log('Timed out. No page content, sending 504.');
+          util.warn('Worker (pid ' + process.pid + '): Timed out. No page content, sending 504.');
           res.send(504);
         } else {
-          util.log('Timed out. Sending request with HTML on the page');
+          util.warn('Worker (pid ' + process.pid + '): Timed out. Sending request with HTML on the page');
           this.onPageEvaluate(req, res);
         }
     } else if ((timeout && req.prerender.stage < 2) || noJsExecutionInFirstSecond) {
-        util.log('Experiencing infinite javascript loop. Killing phantomjs...');
+        util.error('Worker (pid ' + process.pid + '): Experiencing infinite javascript loop. Killing phantomjs...');
         clearInterval(req.prerender.timeoutChecker);
         req.prerender.timeoutChecker = null;
 
@@ -525,7 +529,7 @@ server._sendResponse = function(req, res, options) {
     res.end();
 
     var ms = new Date().getTime() - req.prerender.start.getTime();
-    util.log('got', req.prerender.statusCode, 'in', ms + 'ms', 'for', req.prerender.url);
+    util.info('Worker (pid ' + process.pid + '): got', req.prerender.statusCode, 'in', ms + 'ms', 'for', req.prerender.url);
 
     if((++this.options.worker.iteration >= (this.options.iterations || NUM_ITERATIONS)) || (options && options.abort)) {
         server._killPhantomJS();
@@ -541,10 +545,10 @@ server._killPhantomJS = function() {
 
        //  try {
        //     //not happy with this... but when phantomjs is hanging, it can't exit any normal way
-       //     util.log('pkilling phantomjs');
+       //     util.warn('pkilling phantomjs');
        //     require('child_process').spawn('pkill', ['phantomjs']);
        //     this.phantom = null;
        // } catch(e) {
-       //     util.log('Error killing phantomjs from javascript infinite loop:', e);
+       //     util.error('Error killing phantomjs from javascript infinite loop:', e);
        // }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -48,10 +48,27 @@ util.prepareState = function(req, doubleEncode) {
     };
 };
 
-util.log = function() {
-  if (process.env.DISABLE_LOGGING) {
-    return;
-  }
-
-  console.log.apply(console.log, [new Date().toISOString()].concat(Array.prototype.slice.call(arguments, 0)));
+var LOGGING = {
+  DEBUG: 1,
+  INFO: 2,
+  WARN: 3,
+  ERROR: 4
 };
+
+var LOGGING_LEVEL = LOGGING[(process.env.PRERENDER_LOGGING_LEVEL || '').toUpperCase()] || LOGGING.INFO;
+
+util._log = function(level, func) {
+  level = level.toUpperCase();
+  if (LOGGING_LEVEL <= LOGGING[level]) {
+    var args = Array.prototype.slice.call(arguments, 0);
+    args[0] = new Date().toISOString();
+    args[1] = ' [' + level + ']';
+    func.apply(func, args);
+  }
+};
+
+util.debug = util._log.bind(util, 'DEBUG', console.log);
+util.info = util._log.bind(util, 'INFO', console.info);
+util.warn = util._log.bind(util, 'WARN', console.warn);
+util.error = util._log.bind(util, 'ERROR', console.error);
+util.log = util.debug;


### PR DESCRIPTION
@Woodya -  

Example of this new sweet logging:

```
2016-03-18T21:10:43.300Z Master: starting worker #1
2016-03-18T21:10:43.305Z Worker #1 (pid 84017): reporting for duty
Plugins: logger,screenshotter
Plugins: logger,screenshotter
2016-03-18T21:10:43.429Z Worker (pid 84017): starting phantom on port [12301]
2016-03-18T21:10:43.436Z Worker (pid 84017): Server running on port 6000
2016-03-18T21:10:44.311Z Worker (pid 84017): started phantom
2016-03-18T21:10:49.856Z Worker (pid 84017): request http://127.0.0.1:8000/zapp/application/view?ssn=false&verified=false&pdf=true (pid 84017)
2016-03-18T21:10:49.861Z Worker (pid 84017): prepping http://127.0.0.1:8000/zapp/application/view?ssn=false&verified=false&pdf=true
2016-03-18T21:10:49.867Z Worker (pid 84017): getting http://127.0.0.1:8000/zapp/application/view?ssn=false&verified=false&pdf=true
ga: [["_setAccount","UA-21602263-1"],["_setDomainName","zumper.com"],["_trackPageview"]]
2016-03-18T21:10:51.417Z Worker (pid 84017): got 200 in 1563ms for http://127.0.0.1:8000/zapp/application/view?ssn=false&verified=false&pdf=true (pid 84017)
2016-03-18T21:11:02.279Z Master: worker #1 (pid 84017) died, starting new worker
2016-03-18T21:11:02.282Z Worker #2 (pid 84037): reporting for duty
Plugins: logger,screenshotter
2016-03-18T21:11:02.419Z Worker (pid 84037): starting phantom on port [12302]
2016-03-18T21:11:02.426Z Worker (pid 84037): Server running on port 6000
2016-03-18T21:11:03.202Z Worker (pid 84037): started phantom
```

I currently can't track whether a worker is zombied, because I can't tell which workers are handling which requests.  NOW I CAN!!